### PR TITLE
Fix typo in the README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -34,7 +34,7 @@ or in an initializer
 
 ### Gauge
 
-    widget = Ducksboard::Graph.new(1235)
+    widget = Ducksboard::Gauge.new(1235)
     widget.value = 0.93
     widget.save
 


### PR DESCRIPTION
This commit just fixes a typo in the README file, in the gauge example.
